### PR TITLE
added requestTimeout, and try/catch around JSON.parse

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,12 @@ Require forecast.io
 var Forecast = require('forecast.io');
 ```
 
-Instantiate an instance of Forecast. You'll need to provide options specifying your forecast.io API Key.
+Instantiate an instance of Forecast. You'll need to provide options specifying your forecast.io API Key. You may also add a `requestTimeout` option, which defaults to 2500 if not provided.
 
 ```
 var options = {
-  APIKey: process.env.FORECAST_API_KEY
+  APIKey: process.env.FORECAST_API_KEY,
+  requestTimeout: 1000
 },
 forecast = new Forecast(options);
 ```

--- a/lib/index.js
+++ b/lib/index.js
@@ -18,6 +18,7 @@ function Forecast (options) {
   if ( ! options) throw new ForecastError('APIKey must be set on Forecast options');
   if ( ! options.APIKey) throw new ForecastError('APIKey must be set on Forecast options');
   this.APIKey = options.APIKey;
+  this.requestTimeout = options.timeout || 2500
   this.url = 'https://api.forecast.io/forecast/' + options.APIKey + '/';
 }
 
@@ -37,11 +38,15 @@ Forecast.prototype.get = function get (latitude, longitude, options, callback) {
 
   log('get ' + url);
 
-  request.get(url, function (err, res, data) {
+  request.get({uri:url, timeout:this.requestTimeout}, function (err, res, data) {
     if (err) {
       callback(err);
     } else {
-      data = JSON.parse(data);
+      try {
+        data = JSON.parse(data);
+      } catch(e) {
+        return callback(e, res, data);
+      }
       callback(null, res, data);
     }
   });
@@ -64,7 +69,7 @@ Forecast.prototype.getAtTime = function getAtTime (latitude, longitude, time, op
 
   log('get ' + url);
 
-  request.get(url, function (err, res, data) {
+  request.get({uri:url, timeout:this.requestTimeout}, function (err, res, data) {
     if (err) {
       callback(err);
     } else {


### PR DESCRIPTION
added requestTimeout, and try/catch around JSON.parse in case Forecast.io returns something other than JSON (for instance, a “requests exceeded” message).
