### PR TITLE
Stop parse er from crashing server

### DIFF
--- a/index.js
+++ b/index.js
@@ -76,8 +76,12 @@ Forecast.prototype.getAtTime = function getAtTime (latitude, longitude, time, op
     if (err) {
       callback(err);
     } else {
-      data = JSON.parse(data);
-      callback(null, res, data);
+      try {
+        data = JSON.parse(data);
+        callback(null, res, data);
+      } catch(parseEr) {
+        callback(parseEr);
+      }
     }
   });
 };

--- a/index.js
+++ b/index.js
@@ -55,7 +55,12 @@ Forecast.prototype.get = function get (latitude, longitude, options, callback) {
     if (err) {
       callback(err);
     } else if(res.headers['content-type'].indexOf('application/json') > -1) {
-      callback(null, res, JSON.parse(data));
+      try{
+        data = JSON.parse(data);
+      } catch (parseEr) {
+        return callback(parseEr);
+      };
+      callback(null, res, data);
     } else if(res.statusCode === 200) {
       callback(null, res, data);
     } else {
@@ -78,10 +83,10 @@ Forecast.prototype.getAtTime = function getAtTime (latitude, longitude, time, op
     } else {
       try {
         data = JSON.parse(data);
-        callback(null, res, data);
       } catch(parseEr) {
-        callback(parseEr);
-      }
+        return callback(parseEr);
+      };
+      callback(null, res, data);
     }
   });
 };


### PR DESCRIPTION
`Cannot GET /forecast/__APIKEY__/39.63953756436671,-91.3623046875,10/22/2014T10:22:00?units=us`

was my `data`, because my date was messed up.  Only problem was that it was taking down the whole server.  This should fix that.
