### PR TITLE
Update url endpoint

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ function Forecast (options) {
   if ( ! options.APIKey) throw new ForecastError('APIKey must be set on Forecast options');
   this.APIKey = options.APIKey;
   this.requestTimeout = options.timeout || 2500
-  this.url = 'https://api.forecast.io/forecast/' + options.APIKey + '/';
+  this.url = 'https://api.darksky.net/forecast/' + options.APIKey + '/';
 }
 
 


### PR DESCRIPTION
forecast.io is being rolled into the darksky umbrella. As such the API endpoint has changed. The old one will continue to work (no end date given) but they want people to change.