### PR TITLE
Add support for gzip compression when making HTTP requests

### DIFF
--- a/index.js
+++ b/index.js
@@ -51,7 +51,7 @@ Forecast.prototype.get = function get (latitude, longitude, options, callback) {
 
   var url = this.buildUrl(latitude, longitude, options);
 
-  request.get({uri:url, timeout:this.requestTimeout}, function (err, res, data) {
+  request.get({uri:url, timeout:this.requestTimeout, gzip:true}, function (err, res, data) {
     if (err) {
       callback(err);
     } else if(res.headers['content-type'].indexOf('application/json') > -1) {
@@ -72,7 +72,7 @@ Forecast.prototype.getAtTime = function getAtTime (latitude, longitude, time, op
 
   var url = this.buildUrl(latitude, longitude, time, options);
 
-  request.get({uri:url, timeout:this.requestTimeout}, function (err, res, data) {
+  request.get({uri:url, timeout:this.requestTimeout, gzip:true}, function (err, res, data) {
     if (err) {
       callback(err);
     } else {


### PR DESCRIPTION
The Forecast Data API supports HTTP compression. The Dark Sky team recommend using it, as it will make responses much smaller over the wire. To enable it, we simply need to add an Accept-Encoding: gzip header to all requests. The `request` library supports this through the `gzip:true` option. 

https://darksky.net/dev/docs/response

https://www.npmjs.com/package/request